### PR TITLE
Moving Free42 directory to XDG_DATA_HOME

### DIFF
--- a/gtk/shell_main.cc
+++ b/gtk/shell_main.cc
@@ -453,7 +453,13 @@ static void activate(GtkApplication *theApp, gpointer userData) {
             rename(old_free42dirname, free42dirname);
             // Create a symlink so the old directory will not appear
             // to have just vanished without a trace.
-            symlink(free42dirname, old_free42dirname);
+            // If XDG_DATA_HOME is a subdirectory of HOME, make
+            // the symlink relative.
+            int len = strlen(home);
+            if (strncmp(free42dirname, home, len) == 0 && free42dirname[len] == '/')
+                symlink(free42dirname + len + 1, old_free42dirname);
+            else
+                symlink(free42dirname, old_free42dirname);
         }
     }
 


### PR DESCRIPTION
Phase 1: use $XDG_DATA_HOME/free42 for the Free42 directory instead of $HOME/.free42.
Phase 2 will be XDG_DATA_DIRS support for shared skins, to follow later, based on the existing patch for Arch by @SammysHP.