### PR TITLE
build-gtk: fix logic for systems without gmake

### DIFF
--- a/build-gtk
+++ b/build-gtk
@@ -20,8 +20,7 @@ else
 fi
 
 if [ -z $MK ]; then
-  which gmake >/dev/null
-  if [ $? -eq 0 ]; then
+  if which gmake >/dev/null; then
     MK=gmake
   else
     MK=make


### PR DESCRIPTION
On systems without gmake, “which gmake” will terminate with a non-zero exit
code, causing the script to abort (because the “-e” option is passed to the
shell on the shebang line).

This fixes the test logic by moving the call to “which” within the “if”
statement.