### PR TITLE
Add support for aarch64 in GTK version

### DIFF
--- a/gtk/build-intel-lib.sh
+++ b/gtk/build-intel-lib.sh
@@ -59,7 +59,7 @@ case `uname -m` in
   armv7|armv7l|ppc)
     patch -p0 <../intel-lib-unknown-32bit.patch
     ;;
-  arm64|i86pc)
+  aarch64|arm64|i86pc)
     patch -p0 <../intel-lib-unknown-64bit.patch
     ;;
 esac


### PR DESCRIPTION
This pull request adds support for aarch64 in the GTK version of Free42. It turns out that some Linux systems will report the architecture as `aarch64` and not `amd64`, which causes issues when building the Intel library. This fixes issue #14.