### PR TITLE
Add an error message in PGMMENU if no MVARs are available

### DIFF
--- a/common/core_commands7.cc
+++ b/common/core_commands7.cc
@@ -1188,6 +1188,8 @@ int docmd_rupn(arg_struct *arg) {
 ////////////////////
 
 int docmd_pgmmenu(arg_struct *arg) {
+    if (!mvar_prgms_exist())
+        return ERR_NO_MENU_VARIABLES;
     int err = set_menu_return_err(MENULEVEL_APP, MENU_CATALOG, false);
     if (err == ERR_NONE) {
         set_cat_section(CATSECT_PGM_MENU);


### PR DESCRIPTION
Thomas, I have realised that we did not consider the behaviour if no MVARs are available. I added this error message for the case when no MVAR functions are available in the memory.

I send it as a pull request for your consideration.