### PR TITLE
Initial cross-compiling support

### DIFF
--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -16,6 +16,7 @@
 ###############################################################################
 
 PKG_CONFIG ?= pkg-config
+CXX_FOR_BUILD ?= $(CXX)
 
 CFLAGS = -MMD \
 	 -Wall \
@@ -105,13 +106,13 @@ readtest.o: readtest.c
 	$(CC) $(CFLAGS) -I IntelRDFPMathLib20U1/TESTS -D__intptr_t_defined -DLINUX -c -o $@ $<
 
 skin2cc: skin2cc.cc
-	$(CXX) -o skin2cc skin2cc.cc
+	$(CXX_FOR_BUILD) -o skin2cc skin2cc.cc
 
 skins.cc: skin2cc skin2cc.conf
 	./skin2cc
 
 keymap2cc: keymap2cc.cc
-	$(CXX) -o keymap2cc keymap2cc.cc
+	$(CXX_FOR_BUILD) -o keymap2cc keymap2cc.cc
 
 keymap.cc: keymap2cc keymap.txt
 	./keymap2cc

--- a/gtk/Makefile
+++ b/gtk/Makefile
@@ -15,6 +15,8 @@
 # along with this program; if not, see http://www.gnu.org/licenses/.
 ###############################################################################
 
+PKG_CONFIG ?= pkg-config
+
 CFLAGS = -MMD \
 	 -Wall \
 	 -Wno-parentheses \
@@ -27,7 +29,7 @@ CFLAGS = -MMD \
 	 -Wno-class-memaccess \
 	 -Wno-unknown-warning-option \
 	 -g \
-	 $(shell pkg-config --cflags gtk+-3.0) \
+	 $(shell $(PKG_CONFIG) --cflags gtk+-3.0) \
 	 -DGDK_DISABLE_DEPRECATION_WARNINGS -DGTK_DISABLE_SINGLE_INCLUDES -DGSEAL_ENABLE \
 	 -DVERSION="\"$(shell cat VERSION)\"" \
 	 -DVERSION_PLATFORM="\"$(shell uname -s)\"" \
@@ -42,7 +44,7 @@ CXXFLAGS = $(CFLAGS) \
 	 -fno-rtti \
 	 -D_WCHAR_T_DEFINED
 
-LIBS = gcc111libbid.a $(shell pkg-config --libs gtk+-3.0)
+LIBS = gcc111libbid.a $(shell $(PKG_CONFIG) --libs gtk+-3.0)
 
 ifdef AUDIO_ALSA
 LIBS += -lpthread -ldl


### PR DESCRIPTION
This series contains two changes required to cross-compile Free42:

* Allow overriding `PKG_CONFIG`
* Allow specifying a host compiler for native tools

This has been [tested in Debian](http://crossqa.debian.net/src/free42-nologo), with the caveat that the Intel floating-point math library is built separately there. More work is required in Free42 to set up the math library build appropriately when cross-compiling.