### PR TITLE
Ship .desktop files

### DIFF
--- a/build-gtk
+++ b/build-gtk
@@ -33,6 +33,7 @@ cp gtk/README $PKGNAME
 cp gtk/free42bin $PKGNAME
 cp gtk/free42dec $PKGNAME
 cp gtk/icon-128x128.xpm $PKGNAME/free42icon-128x128.xpm
+cp gtk/*.desktop $PKGNAME/
 strip $PKGNAME/free42bin
 strip $PKGNAME/free42dec
 mkdir -p packages

--- a/gtk/com.thomasokken.Free42bin.desktop
+++ b/gtk/com.thomasokken.Free42bin.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Free42 (binary)
+Comment=HP-42s emulator
+Icon=free42icon-128x128.xpm
+Exec=free42bin
+Categories=GTK;Utility;Calculator;
+Keywords=calculation;arithmetic;scientific;RPN;

--- a/gtk/com.thomasokken.Free42dec.desktop
+++ b/gtk/com.thomasokken.Free42dec.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Free42 (decimal)
+Comment=HP-42s emulator
+Icon=free42icon-128x128.xpm
+Exec=free42dec
+Categories=GTK;Utility;Calculator;
+Keywords=calculation;arithmetic;scientific;RPN;


### PR DESCRIPTION
This provides launchers for Free42 in most Unix-style desktop
environments, when the files are installed in the appropriate
locations.

Signed-off-by: Stephen Kitt <steve@sk2.org>