### PR TITLE
Proposed flip transition for views on iOS

### DIFF
--- a/iphone/Classes/CalcView.mm
+++ b/iphone/Classes/CalcView.mm
@@ -504,8 +504,8 @@ static struct timeval runner_end_time;
     CGRect pf = print.frame;
     if (gstate == UIGestureRecognizerStateBegan) {
         // Make sure the Print-Out view isn't hidden
-        [RootViewController showPrintOut];
-        [RootViewController showMain];
+        [RootViewController showPrintOutWithoutAnimation];
+        [RootViewController showMainWithoutAnimation];
         [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(touchesBegan2) object:nil];
         touchDelayed = 0;
         prevX = self.frame.origin.x;
@@ -520,7 +520,7 @@ static struct timeval runner_end_time;
         if (scale < 1)
             scale = 1;
         if (scale * (p.x + v.x / 16) * dir < -self.bounds.size.width / 3)
-            [RootViewController showPrintOut];
+            [RootViewController showPrintOutWithoutAnimation];
     } else {
         if (dir * p.x > 0)
             p.x = 0;

--- a/iphone/Classes/PrintView.mm
+++ b/iphone/Classes/PrintView.mm
@@ -121,8 +121,8 @@ int print_text_pixel_height;
     CGRect cf = calc.frame;
     if (gstate == UIGestureRecognizerStateBegan) {
         // Make sure the Calculator view isn't hidden
-        [RootViewController showMain];
-        [RootViewController showPrintOut];
+        [RootViewController showMainWithoutAnimation];
+        [RootViewController showPrintOutWithoutAnimation];
         prevX = self.frame.origin.x;
     }
     if (gstate == UIGestureRecognizerStateEnded) {
@@ -135,7 +135,7 @@ int print_text_pixel_height;
         if (scale < 1)
             scale = 1;
         if (scale * (p.x + v.x / 16) * dir < -self.bounds.size.width / 3)
-            [RootViewController showMain];
+            [RootViewController showMainWithoutAnimation];
     } else {
         if (dir * p.x > 0)
             p.x = 0;

--- a/iphone/Classes/RootViewController.h
+++ b/iphone/Classes/RootViewController.h
@@ -68,7 +68,9 @@
 
 + (void) playSound: (int) which;
 + (void) showMain;
++ (void) showMainWithoutAnimation;
 + (void) showPrintOut;
++ (void) showPrintOutWithoutAnimation;
 + (void) showHttpServer;
 + (void) showSelectSkin;
 + (void) showPreferences;

--- a/iphone/Classes/RootViewController.mm
+++ b/iphone/Classes/RootViewController.mm
@@ -219,6 +219,15 @@ void shell_message(const char *message) {
     [instance showMain2];
 }
 
+- (void) showMainWithoutAnimation2 {
+    [self.view bringSubviewToFront:calcView];
+    [calcView setActive:true];
+}
+
++ (void) showMainWithoutAnimation {
+    [instance showMainWithoutAnimation2];
+}
+
 - (void)flipToViewWithBlock:(void (^)(void))block {
     [UIView transitionWithView:self.view duration:0.3 options:UIViewAnimationOptionTransitionFlipFromLeft | UIViewAnimationOptionCurveEaseInOut animations:block completion:NULL];
 }
@@ -232,6 +241,15 @@ void shell_message(const char *message) {
 
 + (void) showPrintOut {
     [instance showPrintOut2];
+}
+
+- (void) showPrintOutWithoutAnimation2 {
+    [calcView setActive:false];
+    [self.view bringSubviewToFront:printView];
+}
+
++ (void) showPrintOutWithoutAnimation {
+    [instance showPrintOutWithoutAnimation2];
 }
 
 - (void) showHttpServer2 {

--- a/iphone/Classes/RootViewController.mm
+++ b/iphone/Classes/RootViewController.mm
@@ -95,6 +95,7 @@ static RootViewController *instance;
     
     [calcView setActive:true];
     [window makeKeyAndVisible];
+    window.backgroundColor = [UIColor blackColor];
     window.rootViewController = self;
 }
 
@@ -208,17 +209,25 @@ void shell_message(const char *message) {
 }
 
 - (void) showMain2 {
-    [self.view bringSubviewToFront:calcView];
-    [calcView setActive:true];
+    [UIView transitionWithView:self.view duration:0.3 options:UIViewAnimationOptionTransitionFlipFromRight | UIViewAnimationOptionCurveEaseInOut animations:^{
+        [self.view bringSubviewToFront:calcView];
+        [calcView setActive:true];
+    } completion:NULL];
 }
 
 + (void) showMain {
     [instance showMain2];
 }
 
+- (void)flipToViewWithBlock:(void (^)(void))block {
+    [UIView transitionWithView:self.view duration:0.3 options:UIViewAnimationOptionTransitionFlipFromLeft | UIViewAnimationOptionCurveEaseInOut animations:block completion:NULL];
+}
+
 - (void) showPrintOut2 {
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:printView];
+    [self flipToViewWithBlock:^{
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:printView];
+    }];
 }
 
 + (void) showPrintOut {
@@ -226,9 +235,11 @@ void shell_message(const char *message) {
 }
 
 - (void) showHttpServer2 {
-    [httpServerView raised];
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:httpServerView];
+    [self flipToViewWithBlock:^{
+        [httpServerView raised];
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:httpServerView];
+    }];
 }
 
 + (void) showHttpServer {
@@ -236,9 +247,11 @@ void shell_message(const char *message) {
 }
 
 - (void) showSelectSkin2 {
-    [selectSkinView raised];
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:selectSkinView];
+    [self flipToViewWithBlock:^{
+        [selectSkinView raised];
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:selectSkinView];
+    }];
 }
 
 + (void) showSelectSkin {
@@ -246,9 +259,11 @@ void shell_message(const char *message) {
 }
 
 - (void) showPreferences2 {
-    [preferencesView raised];
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:preferencesView];
+    [self flipToViewWithBlock:^{
+        [preferencesView raised];
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:preferencesView];
+    }];
 }
 
 + (void) showPreferences {
@@ -256,9 +271,11 @@ void shell_message(const char *message) {
 }
 
 - (void) showAbout2 {
-    [aboutView raised];
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:aboutView];
+    [self flipToViewWithBlock:^{
+        [aboutView raised];
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:aboutView];
+    }];
 }
 
 + (void) showAbout {
@@ -276,7 +293,9 @@ void shell_message(const char *message) {
 }
 
 + (void) doImport {
-    [SelectFileView raiseWithTitle:@"Import Programs" selectTitle:@"Import" types:@"raw,*" initialFile:nil selectDir:NO callbackObject:instance callbackSelector:@selector(doImport2:)];
+    [instance flipToViewWithBlock:^{
+        [SelectFileView raiseWithTitle:@"Import Programs" selectTitle:@"Import" types:@"raw,*" initialFile:nil selectDir:NO callbackObject:instance callbackSelector:@selector(doImport2:)];
+    }];
 }
 
 - (void) doImport2:(NSString *) path {
@@ -284,9 +303,11 @@ void shell_message(const char *message) {
 }
 
 + (void) doExport:(BOOL)share {
-    [instance.selectProgramsView raised:share];
-    [instance.calcView setActive:false];
-    [instance.self.view bringSubviewToFront:instance.selectProgramsView];
+    [instance flipToViewWithBlock:^{
+        [instance.selectProgramsView raised:share];
+        [instance.calcView setActive:false];
+        [instance.self.view bringSubviewToFront:instance.selectProgramsView];
+    }];
 }
 
 - (void) showLoadSkin2 {
@@ -300,13 +321,15 @@ void shell_message(const char *message) {
 }
 
 - (void) showStates2:(NSString *)stateName {
-    [statesView raised];
-    if (stateName != nil) {
-        [statesView selectState:stateName];
-        [stateName release];
-    }
-    [calcView setActive:false];
-    [self.view bringSubviewToFront:statesView];
+    [self flipToViewWithBlock:^{
+        [statesView raised];
+        if (stateName != nil) {
+            [statesView selectState:stateName];
+            [stateName release];
+        }
+        [calcView setActive:false];
+        [self.view bringSubviewToFront:statesView];
+    }];
 }
 
 + (void) showStates:(NSString *)stateName {


### PR DESCRIPTION
Hi Thomas,
This is a proposed flip transition animation for switching between the calculator view
and preferences, states, skins, etc. on iOS. Instead of an abrupt switch, we transition with a flip animation which gives the user visual feedback and is more pleasing to the eye. Going back to the calculator view flips the opposite way. 

The code is minimal. The original calls were just wrapped in a call to `+[UIView transitionWithView:duration:options:animations:completion:]`, API compatible with iOS 4.0+.