### PR TITLE
Proposal to pin skin to bottom when maintaining aspect ratio on iPhone

### DIFF
--- a/iphone/Classes/shell_skin_iphone.mm
+++ b/iphone/Classes/shell_skin_iphone.mm
@@ -540,7 +540,7 @@ void skin_load(long *width, long *height) {
             skin_offset_h = ([CalcView width] - skin.width / skin_scale_h) / 2;
         } else {
             skin_scale_v = skin_scale_h;
-            skin_offset_v = ([CalcView height] - skin.height / skin_scale_v) / 2;
+            skin_offset_v = ([CalcView height] - skin.height / skin_scale_v);
         }
     }
 


### PR DESCRIPTION
Rather than center the skin vertically, this PR pins the skin to the bottom of the screen when the user's preference is to maintain the aspect ratio. This is more comfortable/ergonomic as it is easier to reach all the buttons, particularly for users with smaller hands using compact skins.